### PR TITLE
[FEAT] 게시글 soft delete 변경사항, 이미지 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,9 @@ dependencies {
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
     implementation 'org.springframework.boot:spring-boot-starter-mustache'
+
+    //s3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('bootBuildImage') {

--- a/src/main/java/com/team/twodari/board/controller/BoardController.java
+++ b/src/main/java/com/team/twodari/board/controller/BoardController.java
@@ -7,6 +7,7 @@ import com.team.twodari.board.entity.BoardEntity;
 import com.team.twodari.board.service.BoardService;
 import com.team.twodari.subBoard.entity.SubBoardEntity;
 import com.team.twodari.subBoard.service.SubBoardService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -15,14 +16,10 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/board")
+@RequiredArgsConstructor
 public class BoardController {
     private final BoardService boardService;
     private final SubBoardService subBoardService;
-
-    public BoardController(BoardService boardService, SubBoardService subBoardService) {
-        this.boardService = boardService;
-        this.subBoardService = subBoardService;
-    }
 
     @PostMapping("/create")
     public ResponseEntity<String> createBoard(@RequestBody BoardCreateDto dto) {
@@ -39,14 +36,12 @@ public class BoardController {
     public ResponseEntity<BoardReadDto> getBoardBySeq(@PathVariable Long boardSeq) {
         BoardEntity board = boardService.getBoardBySeq(boardSeq);
 
-        if (board != null) {
-            List<SubBoardEntity> subBoards = subBoardService.getSubBoardsByBoardSeq(boardSeq);
+        if (board == null) return ResponseEntity.notFound().build();
 
-            BoardReadDto boardReadDto = BoardReadDto.fromEntity(board, subBoards);
-            return ResponseEntity.ok(boardReadDto);
-        }
+        List<SubBoardEntity> subBoards = subBoardService.getSubBoardsByBoardSeq(boardSeq);
 
-        return ResponseEntity.notFound().build();
+        BoardReadDto boardReadDto = BoardReadDto.fromEntity(board, subBoards);
+        return ResponseEntity.ok(boardReadDto);
     }
 
     @PutMapping("/{boardSeq}")

--- a/src/main/java/com/team/twodari/board/dto/BoardCreateDto.java
+++ b/src/main/java/com/team/twodari/board/dto/BoardCreateDto.java
@@ -6,7 +6,7 @@ import lombok.*;
 
 @Getter
 @ToString
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class BoardCreateDto {
 

--- a/src/main/java/com/team/twodari/board/dto/BoardReadDto.java
+++ b/src/main/java/com/team/twodari/board/dto/BoardReadDto.java
@@ -3,16 +3,13 @@ package com.team.twodari.board.dto;
 import com.team.twodari.board.entity.BoardEntity;
 import com.team.twodari.subBoard.entity.SubBoardEntity;
 import jakarta.validation.constraints.NotBlank;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 import java.util.List;
 
 @Getter
 @ToString
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class BoardReadDto {
 

--- a/src/main/java/com/team/twodari/board/dto/BoardUpdateDto.java
+++ b/src/main/java/com/team/twodari/board/dto/BoardUpdateDto.java
@@ -2,14 +2,11 @@ package com.team.twodari.board.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 @Getter
 @ToString
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class BoardUpdateDto {
 

--- a/src/main/java/com/team/twodari/board/entity/BoardEntity.java
+++ b/src/main/java/com/team/twodari/board/entity/BoardEntity.java
@@ -41,4 +41,8 @@ public class BoardEntity extends BaseEntity {
         this.title = title;
         this.accessRole = accessRole;
     }
+
+    public void deleteEntity() {
+        this.deleted = "Y";
+    }
 }

--- a/src/main/java/com/team/twodari/board/service/BoardService.java
+++ b/src/main/java/com/team/twodari/board/service/BoardService.java
@@ -35,7 +35,8 @@ public class BoardService {
     }
 
     public Long updateBoard(Long boardSeq, BoardUpdateDto updateDto) {
-        BoardEntity board = boardRepository.findById(boardSeq).orElseThrow(()-> new ResponseStatusException(HttpStatus.NOT_FOUND, "게시글이 존재하지 않습니다"));
+        BoardEntity board = boardRepository.findById(boardSeq)
+                .orElseThrow(()-> new ResponseStatusException(HttpStatus.NOT_FOUND, "게시글이 존재하지 않습니다"));
         board.updateEntity(updateDto.getTitle(), updateDto.getAccessRole());
         boardRepository.save(board);
 
@@ -43,10 +44,10 @@ public class BoardService {
     }
 
     public void deleteBoard(Long boardSeq) {
-        if (!boardRepository.existsById(boardSeq)) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "게시글이 존재하지 않습니다");
-        }
+        BoardEntity board = boardRepository.findById(boardSeq)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "게시글이 존재하지 않습니다"));
+        board.deleteEntity();
 
-        boardRepository.deleteById(boardSeq);
+        boardRepository.save(board);
     }
 }

--- a/src/main/java/com/team/twodari/board/service/BoardService.java
+++ b/src/main/java/com/team/twodari/board/service/BoardService.java
@@ -30,7 +30,8 @@ public class BoardService {
     }
 
     public BoardEntity getBoardBySeq(Long boardSeq) {
-        return boardRepository.findById(boardSeq).orElse(null);
+        return boardRepository.findById(boardSeq)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "게시글이 존재하지 않습니다"));
     }
 
     public Long updateBoard(Long boardSeq, BoardUpdateDto updateDto) {

--- a/src/main/java/com/team/twodari/common/config/s3/S3Config.java
+++ b/src/main/java/com/team/twodari/common/config/s3/S3Config.java
@@ -1,0 +1,33 @@
+package com.team.twodari.common.config.s3;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return (AmazonS3Client) AmazonS3ClientBuilder
+                .standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .build();
+    }
+}

--- a/src/main/java/com/team/twodari/image/controller/ImageController.java
+++ b/src/main/java/com/team/twodari/image/controller/ImageController.java
@@ -17,7 +17,7 @@ public class ImageController {
         this.imageService = imageService;
     }
 
-    @PostMapping("/upload/{subBoardSeq}")
+    @PostMapping("/upload/subBoard/{subBoardSeq}")
     public ResponseEntity<String> uploadImage(@RequestParam("file") MultipartFile file,
                                               @PathVariable Long subBoardSeq) {
         try {
@@ -29,4 +29,12 @@ public class ImageController {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("이미지 업로드 실패");
         }
     }
+
+    @DeleteMapping("/subBoard/{subBoardSeq}/delete/{imageSeq}")
+    public ResponseEntity<Void> deleteImage(@PathVariable Long subBoardSeq,
+                                            @PathVariable Long imageSeq) {
+        imageService.deleteImage(subBoardSeq, imageSeq);
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/src/main/java/com/team/twodari/image/controller/ImageController.java
+++ b/src/main/java/com/team/twodari/image/controller/ImageController.java
@@ -1,9 +1,32 @@
 package com.team.twodari.image.controller;
 
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import com.team.twodari.image.service.ImageService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 @RestController
 @RequestMapping("/image")
 public class ImageController {
+    private final ImageService imageService;
+
+    public ImageController(ImageService imageService) {
+        this.imageService = imageService;
+    }
+
+    @PostMapping("/upload/{subBoardSeq}")
+    public ResponseEntity<String> uploadImage(@RequestParam("file") MultipartFile file,
+                                              @PathVariable Long subBoardSeq) {
+        try {
+            String imageUrl = imageService.uploadImage(file, subBoardSeq);
+
+            return ResponseEntity.ok("이미지 업로드 성공. Image URL : " + imageUrl);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("이미지 업로드 실패");
+        }
+    }
 }

--- a/src/main/java/com/team/twodari/image/entity/ImageEntity.java
+++ b/src/main/java/com/team/twodari/image/entity/ImageEntity.java
@@ -1,10 +1,8 @@
 package com.team.twodari.image.entity;
 
 import com.team.twodari.common.entity.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import com.team.twodari.subBoard.entity.SubBoardEntity;
+import jakarta.persistence.*;
 import lombok.*;
 
 @Table(name = "TB_IMAGE")
@@ -17,12 +15,9 @@ import lombok.*;
 public class ImageEntity extends BaseEntity {
     // 이미지 일련번호
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(columnDefinition = "INT")
-    private Integer imageSeq;
-
-    // 보조 게시판 일련번호
-    @Column(columnDefinition = "INT")
-    private Integer subBoardSeq;
+    private Long imageSeq;
 
     // 경로
     @Column(columnDefinition = "VARCHAR(200)")
@@ -31,4 +26,8 @@ public class ImageEntity extends BaseEntity {
     // 삭제플래그
     @Column(columnDefinition = "CHAR(1)")
     private String deleted;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sub_board_seq", nullable = false)
+    private SubBoardEntity subBoard;
 }

--- a/src/main/java/com/team/twodari/image/entity/ImageEntity.java
+++ b/src/main/java/com/team/twodari/image/entity/ImageEntity.java
@@ -30,4 +30,8 @@ public class ImageEntity extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sub_board_seq", nullable = false)
     private SubBoardEntity subBoard;
+
+    public void deleteEntity() {
+        this.deleted = "Y";
+    }
 }

--- a/src/main/java/com/team/twodari/image/repository/ImageRepository.java
+++ b/src/main/java/com/team/twodari/image/repository/ImageRepository.java
@@ -1,4 +1,7 @@
 package com.team.twodari.image.repository;
 
-public interface ImageRepository {
+import com.team.twodari.image.entity.ImageEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ImageRepository extends JpaRepository<ImageEntity, Long> {
 }

--- a/src/main/java/com/team/twodari/image/service/ImageService.java
+++ b/src/main/java/com/team/twodari/image/service/ImageService.java
@@ -37,5 +37,20 @@ public class ImageService {
         return imageUrl;
     }
 
+    public void deleteImage(Long subBoardSeq, Long imageSeq) {
+        if (isExistSubBoard(subBoardSeq)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "서브보드가 존재하지 않습니다");
+        }
+
+        ImageEntity image = imageRepository.findById(imageSeq)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "이미지가 존재하지 않습니다"));
+        image.deleteEntity();
+
+        imageRepository.save(image);
+    }
+
+    private boolean isExistSubBoard(Long subBoardSeq) {
+        return subBoardSeq != null && !subBoardRepository.existsById(subBoardSeq);
+    }
 
 }

--- a/src/main/java/com/team/twodari/image/service/ImageService.java
+++ b/src/main/java/com/team/twodari/image/service/ImageService.java
@@ -1,9 +1,41 @@
 package com.team.twodari.image.service;
 
+import com.team.twodari.image.entity.ImageEntity;
+import com.team.twodari.image.repository.ImageRepository;
+import com.team.twodari.subBoard.entity.SubBoardEntity;
+import com.team.twodari.subBoard.repository.SubBoardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.io.IOException;
 
 @Service
 @Transactional
+@RequiredArgsConstructor
 public class ImageService {
+    private final ImageRepository imageRepository;
+    private final S3UploadService s3UploadService;
+    private final SubBoardRepository subBoardRepository;
+
+    public String uploadImage(MultipartFile file, Long subBoardSeq) throws IOException {
+        SubBoardEntity subBoard = subBoardRepository.findById(subBoardSeq)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "서브보드가 존재하지 않습니다"));
+
+        // 이미지를 S3에 업로드하고 S3에 저장된 URL을 반환
+        String imageUrl = s3UploadService.upload(file);
+
+        ImageEntity image = ImageEntity.builder()
+                .subBoard(subBoard)
+                .path(imageUrl)
+                .build();
+
+        imageRepository.save(image);
+        return imageUrl;
+    }
+
+
 }

--- a/src/main/java/com/team/twodari/image/service/S3UploadService.java
+++ b/src/main/java/com/team/twodari/image/service/S3UploadService.java
@@ -1,0 +1,35 @@
+package com.team.twodari.image.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Service
+public class S3UploadService {
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    private final AmazonS3 amazonS3;
+
+    public S3UploadService(AmazonS3 amazonS3) {
+        this.amazonS3 = amazonS3;
+    }
+
+    public String upload(MultipartFile multipartFile) throws IOException {
+        String s3FileName = UUID.randomUUID() + "-" + multipartFile.getOriginalFilename();
+
+        ObjectMetadata objMeta = new ObjectMetadata();
+        objMeta.setContentLength(multipartFile.getSize());
+
+        amazonS3.putObject(bucket, s3FileName, multipartFile.getInputStream(), objMeta);
+
+        String imageUrl = "https://" + bucket + ".s3.amazonaws.com/" + s3FileName;
+
+        return imageUrl;
+    }
+}

--- a/src/main/java/com/team/twodari/subBoard/dto/SubBoardCreateDto.java
+++ b/src/main/java/com/team/twodari/subBoard/dto/SubBoardCreateDto.java
@@ -2,14 +2,11 @@ package com.team.twodari.subBoard.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 @Getter
 @ToString
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class SubBoardCreateDto {
 

--- a/src/main/java/com/team/twodari/subBoard/dto/SubBoardReadDto.java
+++ b/src/main/java/com/team/twodari/subBoard/dto/SubBoardReadDto.java
@@ -1,14 +1,11 @@
 package com.team.twodari.subBoard.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 @Getter
 @ToString
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class SubBoardReadDto {
 

--- a/src/main/java/com/team/twodari/subBoard/dto/SubBoardUpdateDto.java
+++ b/src/main/java/com/team/twodari/subBoard/dto/SubBoardUpdateDto.java
@@ -2,14 +2,11 @@ package com.team.twodari.subBoard.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 @Getter
 @ToString
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class SubBoardUpdateDto {
 

--- a/src/main/java/com/team/twodari/subBoard/entity/SubBoardEntity.java
+++ b/src/main/java/com/team/twodari/subBoard/entity/SubBoardEntity.java
@@ -34,5 +34,9 @@ public class SubBoardEntity extends BaseEntity {
     public void updateEntity(String contents) {
         this.contents = contents;
     }
+
+    public void deleteEntity() {
+        this.deleted = "Y";
+    }
 }
 

--- a/src/main/java/com/team/twodari/subBoard/service/SubBoardService.java
+++ b/src/main/java/com/team/twodari/subBoard/service/SubBoardService.java
@@ -43,7 +43,7 @@ public class SubBoardService {
     }
 
     public Long updateSubBoard(Long boardSeq, Long subBoardSeq, SubBoardUpdateDto updateDto) {
-        if (boardSeq != null && !boardRepository.existsById(boardSeq)) {
+        if (isExistBoard(boardSeq)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "보드가 존재하지 않습니다");
         }
 
@@ -56,8 +56,12 @@ public class SubBoardService {
         return subBoard.getSubBoardSeq();
     }
 
+    private boolean isExistBoard(Long boardSeq) {
+        return boardSeq != null && !boardRepository.existsById(boardSeq);
+    }
+
     public void deleteSubBoard(Long boardSeq, Long subBoardSeq) {
-        if (boardSeq != null && !boardRepository.existsById(boardSeq)) {
+        if (isExistBoard(boardSeq)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "보드가 존재하지 않습니다");
         }
 

--- a/src/main/java/com/team/twodari/subBoard/service/SubBoardService.java
+++ b/src/main/java/com/team/twodari/subBoard/service/SubBoardService.java
@@ -56,10 +56,6 @@ public class SubBoardService {
         return subBoard.getSubBoardSeq();
     }
 
-    private boolean isExistBoard(Long boardSeq) {
-        return boardSeq != null && !boardRepository.existsById(boardSeq);
-    }
-
     public void deleteSubBoard(Long boardSeq, Long subBoardSeq) {
         if (isExistBoard(boardSeq)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "보드가 존재하지 않습니다");
@@ -67,7 +63,12 @@ public class SubBoardService {
 
         SubBoardEntity subBoard = subBoardRepository.findById(subBoardSeq)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "서브보드가 존재하지 않습니다"));
+        subBoard.deleteEntity();
 
-        subBoardRepository.delete(subBoard);
+        subBoardRepository.save(subBoard);
+    }
+
+    private boolean isExistBoard(Long boardSeq) {
+        return boardSeq != null && !boardRepository.existsById(boardSeq);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,3 +31,16 @@ spring:
 #            token-uri: https://nid.naver.com/oauth2.0/token
 #            user-info-uri: https://openapi.naver.com/v1/nid/me
 #            user-name-attribute: response
+
+cloud:
+  aws:
+    s3:
+      bucket: ${AWS.BUCKET}
+    credentials:
+      access-key: ${AWS.ACCESS_KEY}
+      secret-key: ${AWS.SECRET_KEY}
+    region:
+      static: ap-northeast-2
+      auto: false
+    stack:
+      auto: false

--- a/src/test/java/com/team/twodari/base/BaseControllerTest.java
+++ b/src/test/java/com/team/twodari/base/BaseControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.team.twodari.admin.user.AdminUserService;
 import com.team.twodari.board.controller.facade.BoardFacadeService;
 import com.team.twodari.board.service.BoardService;
+import com.team.twodari.image.service.ImageService;
 import com.team.twodari.platform.service.PlatformService;
 import com.team.twodari.subBoard.service.SubBoardService;
 import com.team.twodari.tag.service.TagService;
@@ -45,7 +46,8 @@ public abstract class BaseControllerTest {
     @MockBean
     protected SubBoardService subBoardService;
 
-
+    @MockBean
+    protected ImageService imageService;
 
     @BeforeEach
     void mockMvcSetUp(

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -16,3 +16,16 @@ JWT:
   TOKEN-VALIDITY-IN-SECONDS: 86400
   SECRET2: secretKeysecretKeysecretKeysecretKeysecretKeysecretKeysecretKeysecretKeysecretKeysecretKey
   TOKEN-VALIDITY-IN-SECONDS2: 97400
+
+cloud:
+  aws:
+    s3:
+      bucket: besp1-2team-s3-bucket
+    credentials:
+      access-key: AKIAZ4PB2L4LBPVI6DXO
+      secret-key: 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
+    region:
+      static: ap-northeast-2
+      auto: false
+    stack:
+      auto: false


### PR DESCRIPTION
## Summary
---
Board, SubBoard 삭제 기능 hard delete -> soft delete 로 변경
SubBoard 이미지 업로드 삭제 기능 구현 및 DB 테스트

## Describe your changes
---
대표 카드와 서브 카드 삭제 기능 변경했습니다.
soft delete 가 어떤 방식인지 이해는 했습니다만 
삭제 시 데이터가 Y 로 변경되게 구현했는데 이게 맞는지 리뷰 부탁드려요.

이미지 업로드 기능은 amazon S3를 이용했고 수정 기능은 필요 없다고 생각해서 삭제 기능만 구현했습니다.
테스트는 postman 을 사용했습니다.
리뷰 부탁드립니다!

## Issue number and link
---